### PR TITLE
Add ca-certificates so vault can make SSL calls out

### DIFF
--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -14,7 +14,7 @@ ENV VAULT_TMP /tmp/vault.zip
 ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
-RUN apk --update add wget bash && \
+RUN apk --update add wget bash ca-certificates && \
     wget --no-check-certificate --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip && \
     unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
     rm -f ${VAULT_TMP}


### PR DESCRIPTION
Without CA certs, Vault can't call out to anything over SSL.  For example, the AWS secret backend needs to call AWS APIs, which is done over SSL.
