### PR TITLE
Restore wget certificate check

### DIFF
--- a/0.1.0/Dockerfile
+++ b/0.1.0/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --update add \
       wget \
       bash \
       ca-certificates &&\
-    wget --no-check-certificate --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
+    wget --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
     unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
     rm -f ${VAULT_TMP}
 

--- a/0.1.1/Dockerfile
+++ b/0.1.1/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --update add \
       wget \
       bash \
       ca-certificates &&\
-    wget --no-check-certificate --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
+    wget --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
     unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
     rm -f ${VAULT_TMP}
 

--- a/0.1.2/Dockerfile
+++ b/0.1.2/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --update add \
       wget \
       bash \
       ca-certificates &&\
-    wget --no-check-certificate --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
+    wget --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
     unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
     rm -f ${VAULT_TMP}
 

--- a/0.2.0/Dockerfile
+++ b/0.2.0/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --update add \
       wget \
       bash \
       ca-certificates &&\
-    wget --no-check-certificate --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
+    wget --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
     unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
     rm -f ${VAULT_TMP}
 

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -18,7 +18,7 @@ RUN apk --update add \
       wget \
       bash \
       ca-certificates &&\
-    wget --no-check-certificate --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
+    wget --quiet --output-document=${VAULT_TMP} https://dl.bintray.com/mitchellh/vault/vault_${VAULT_VERSION}_linux_amd64.zip &&\
     unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
     rm -f ${VAULT_TMP}
 


### PR DESCRIPTION
## What

Remove `--no-certificate-check` from the template file and then apply to the various version subdirectories.
## Why

No cert allows MITM and greater opportunities for tainting the build.
