### PR TITLE
Remove the extra vault command from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ By default the container will run the *vault* command showing the version. Simpl
 4. Run a docker container with that image (change [your_name] as done above)
 
    ```sh
-   docker run -it [your_name]/vault:latest vault -help
+   docker run -it [your_name]/vault:latest -help
    ```
 
 # User Feedback


### PR DESCRIPTION
## What

Tweaks a `docker run` example given in the README
## Why

Current example can lead to brief confusion for the reader. The next logical step is to try `docker run -it [your_name]/vault:latest vault server -dev` which will fail due to the `ENTRYPOINT` specified in the Dockerfile.
