### PR TITLE
Image size improvements

### DIFF
--- a/0.1.2/Dockerfile
+++ b/0.1.2/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/0.2.0/Dockerfile
+++ b/0.2.0/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/0.3.1/Dockerfile
+++ b/0.3.1/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/0.4.0/Dockerfile
+++ b/0.4.0/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/0.4.1/Dockerfile
+++ b/0.4.1/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/0.5.0/Dockerfile
+++ b/0.5.0/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/0.5.1/Dockerfile
+++ b/0.5.1/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/0.5.2/Dockerfile
+++ b/0.5.2/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/0.5.3/Dockerfile
+++ b/0.5.3/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/0.6.0/Dockerfile
+++ b/0.6.0/Dockerfile
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -9,12 +9,13 @@ ENV VAULT_HOME /usr/local/bin
 ENV PATH $PATH:${VAULT_HOME}
 
 RUN apk --no-cache add \
-      bash \
-      ca-certificates \
-      wget &&\
-    wget --quiet --output-document=${VAULT_TMP} https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip &&\
-    unzip ${VAULT_TMP} -d ${VAULT_HOME} &&\
-    rm -f ${VAULT_TMP}
+    ca-certificates && \
+    cd /tmp && \
+    wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault_${VAULT_VERSION}_linux_amd64.zip ${VAULT_TMP} && \
+    unzip ${VAULT_TMP} -d ${VAULT_HOME} && \
+    rm -f ${VAULT_TMP} && \
+    apk --no-cache del ca-certificates
 
 # Listener API tcp port
 EXPOSE 8200


### PR DESCRIPTION
This improves resulting build size of the image.
- Do not install bash and wget
- remove ca-certificates at the end. In my view you are REQUIRED to provide the necessary proper certificates when starting/querying
